### PR TITLE
Detect login type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,19 @@ executors:
 commands:
   azure-cli-tests:
     description: "Verifies azure-cli install"
+    parameters:
+      login-with-service-principal:
+        type: boolean
+        default: false
+        description: Logs in with service principal
+      login-with-user:
+        type: boolean
+        default: false
+        description: Logs in with user
+      detect-login-type:
+        type: boolean
+        default: false
+        description: Detect the type of login to be performed
     steps:
       - azure-cli/install
 
@@ -26,7 +39,20 @@ commands:
           name: Verify Azure install
           command: az -v
 
-      - azure-cli/login-with-service-principal
+      - when:
+          condition: << parameters.login-with-service-principal >>
+          steps:
+            - azure-cli/login-with-service-principal
+
+      - when:
+          condition: << parameters.login-with-user >>
+          steps:
+            - azure-cli/login-with-user
+
+      - when:
+          condition: << parameters.detect-login-type >>
+          steps:
+            - azure-cli/login-with-user-or-service-principal
 
       - run:
           name: Verify login
@@ -36,18 +62,21 @@ jobs:
   test-orb-python:
     executor: python
     steps:
-      - azure-cli-tests
+      - azure-cli-tests:
+          detect-login-type: true
 
   test-orb-golang:
     executor: golang
     steps:
-      - azure-cli-tests
+      - azure-cli-tests:
+          login-with-service-principal: true
 
   test-orb-azure-docker:
     executor: azure-cli/azure-docker
     steps:
       - run: az -v
-      - azure-cli-tests
+      - azure-cli-tests:
+          login-with-service-principal: true
 
 # yaml anchor filters
 integration-dev_filters: &integration-dev_filters

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You may use the following commands provided by this orb directly from your own j
 
 - [**login-with-service-principal**](#login-with-service-principal) - Allows you to login to the Azure CLI with a Service Principal
 
+- [**login-with-user-or-service-principal**](#login-with-user-or-service-principal) - Allows you to login to the Azure CLI, where the login type (user/Service Principal) is determined based on detection of the relevant environment variables.
+
 #### `install`
 
 ##### Example
@@ -131,4 +133,47 @@ workflows:
   example-workflow:
     jobs:
       - login-to-azure
+```
+
+#### `login-with-user-or-service-principal`
+
+##### Parameters
+
+| Parameter | type | default | description |
+|-----------|------|---------|-------------|
+| `azure-username` | `env_var_name` | `AZURE_USERNAME` | Environment variable storing your Azure username |
+| `azure-password` | `env_var_name` | `AZURE_PASSWORD` | Environment variable storing your Azure password |
+| `alternate-tenant` | `boolean` | `false` | Set to True to use the `--tenant az` login option |
+| `azure-tenant` | `env_var_name` | `AZURE_TENANT` | Environment variable storing your Azure tenant, necessary if `alternate-tenant` is set to true |
+| `azure-sp` | `env_var_name` | `AZURE_SP` | Name of environment variable storing the full name of the Service Principal, in the form `http://app-url` |
+| `azure-sp-password` | `env_var_name` | `AZURE_SP_PASSWORD` | Name of environment variable storing the password for the Service Principal |
+| `azure-sp-tenant` | `env_var_name` |  `AZURE_SP_TENANT` | Name of environment variable storing the tenant ID for the Service Principal |
+
+##### Example
+
+```yaml
+description: >
+  Log into Azure with the login type determined based on
+  environment variable detection.
+
+usage:
+  version: 2.1
+
+  orbs:
+    azure-cli: circleci/azure-cli@1.0.0
+
+  jobs:
+    login-to-azure:
+      executor: azure-cli/azure-docker
+      steps:
+        - azure-cli/login-with-user-or-service-principal
+
+        - run:
+            name: List resources of tenant stored as `AZURE_SP_TENANT` env var
+            command: az resource list
+
+  workflows:
+    example-workflow:
+      jobs:
+        - login-to-azure
 ```

--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ workflows:
 
 | Parameter | type | default | description |
 |-----------|------|---------|-------------|
-| `azure-username` | `env_var_name` | `AZURE_USERNAME` | Environment variable storing your Azure username |
-| `azure-password` | `env_var_name` | `AZURE_PASSWORD` | Environment variable storing your Azure password |
-| `alternate-tenant` | `boolean` | `false` | Set to True to use the `--tenant az` login option |
-| `azure-tenant` | `env_var_name` | `AZURE_TENANT` | Environment variable storing your Azure tenant, necessary if `alternate-tenant` is set to true |
-| `azure-sp` | `env_var_name` | `AZURE_SP` | Name of environment variable storing the full name of the Service Principal, in the form `http://app-url` |
-| `azure-sp-password` | `env_var_name` | `AZURE_SP_PASSWORD` | Name of environment variable storing the password for the Service Principal |
-| `azure-sp-tenant` | `env_var_name` |  `AZURE_SP_TENANT` | Name of environment variable storing the tenant ID for the Service Principal |
+| `azure-username` | `env_var_name` | `AZURE_USERNAME` | Environment variable storing your Azure username. Only applicable for user logins. |
+| `azure-password` | `env_var_name` | `AZURE_PASSWORD` | Environment variable storing your Azure password. Only applicable for user logins. |
+| `alternate-tenant` | `boolean` | `false` | Set to True to use the `--tenant az` login option. Only applicable for user logins. |
+| `azure-tenant` | `env_var_name` | `AZURE_TENANT` | Environment variable storing your Azure tenant, necessary if `alternate-tenant` is set to true. Only applicable for user logins. |
+| `azure-sp` | `env_var_name` | `AZURE_SP` | Name of environment variable storing the full name of the Service Principal, in the form `http://app-url`. Only applicable for Service Principal logins. |
+| `azure-sp-password` | `env_var_name` | `AZURE_SP_PASSWORD` | Name of environment variable storing the password for the Service Principal. Only applicable for Service Principal logins. |
+| `azure-sp-tenant` | `env_var_name` |  `AZURE_SP_TENANT` | Name of environment variable storing the tenant ID for the Service Principal. Only applicable for Service Principal logins. |
 
 ##### Example
 

--- a/src/commands/login-with-user-or-service-principal.yml
+++ b/src/commands/login-with-user-or-service-principal.yml
@@ -1,0 +1,79 @@
+description: >
+  Initilize the Azure CLI. Supports login either with a user or with a Service
+  Principal. The type of login is determined by checking if the environment
+  variable storing the Azure username or the environment variable storing the
+  name of the Service Principal is set to a non-empty value.
+
+parameters:
+
+  azure-username:
+    type: env_var_name
+    default: AZURE_USERNAME
+    description: >
+      Environment variable storing your Azure username.
+      Only applicable for user logins.
+
+  azure-password:
+    type: env_var_name
+    default: AZURE_PASSWORD
+    description:  >
+      Environment variable storing your Azure password.
+      Only applicable for user logins.
+
+  alternate-tenant:
+    description: Use an alternate tenant. Only applicable for user logins.
+    type: boolean
+    default: false
+
+  azure-tenant:
+    type: env_var_name
+    default: AZURE_TENANT
+    description: >
+      Environment variable storing your Azure tenant,
+      necessary if `alternate-tenant` is set to true.
+      Only applicable for user logins.
+  
+  azure-sp:
+    type: env_var_name
+    default: AZURE_SP
+    description: >
+      Name of environment variable storing the full name of the
+      Service Principal, in the form http://app-url.
+      Only applicable for Service Principal logins.
+
+  azure-sp-password:
+    type: env_var_name
+    default: AZURE_SP_PASSWORD
+    description: >
+      Name of environment variable storing the password for the
+      Service Principal. Only applicable for Service Principal logins.
+
+  azure-sp-tenant:
+    type: env_var_name
+    default: AZURE_SP_TENANT
+    description: >
+      Name of environment variable storing the tenant ID for the
+      Service Principal. Only applicable for Service Principal logins.
+
+steps:
+  - run:
+      name: Login to the Azure CLI with user or Service Principal
+      command: |
+        if [ -n "${<< parameters.azure-username >>}" ]; then
+          echo "User credentials detected; logging in with user"
+          az login \
+            <<#parameters.alternate-tenant>> \
+            --tenant $<<parameters.azure-tenant>> <</parameters.alternate-tenant>> \
+            -u $<<parameters.azure-username>> \
+            -p $<<parameters.azure-password>>
+        elif [ -n "${<< parameters.azure-sp >>}" ]; then
+          echo "Service Principal credentials detected; logging in with Service Principal"
+          az login \
+            --service-principal \
+            --tenant $<<parameters.azure-sp-tenant>> \
+            -u $<<parameters.azure-sp>> \
+            -p $<<parameters.azure-sp-password>>
+        else
+          echo "Login failed; neither user nor Service Principal credentials were provided"
+          exit 1
+        fi

--- a/src/commands/login-with-user-or-service-principal.yml
+++ b/src/commands/login-with-user-or-service-principal.yml
@@ -32,7 +32,7 @@ parameters:
       Environment variable storing your Azure tenant,
       necessary if `alternate-tenant` is set to true.
       Only applicable for user logins.
-  
+
   azure-sp:
     type: env_var_name
     default: AZURE_SP

--- a/src/examples/login-with-user-or-service-principal.yml
+++ b/src/examples/login-with-user-or-service-principal.yml
@@ -1,0 +1,24 @@
+description: >
+  Log into Azure with the login type determined based on
+  environment variable detection.
+
+usage:
+  version: 2.1
+
+  orbs:
+    azure-cli: circleci/azure-cli@1.0.0
+
+  jobs:
+    login-to-azure:
+      executor: azure-cli/azure-docker
+      steps:
+        - azure-cli/login-with-user-or-service-principal
+
+        - run:
+            name: List resources of tenant stored as `AZURE_SP_TENANT` env var
+            command: az resource list
+
+  workflows:
+    example-workflow:
+      jobs:
+        - login-to-azure


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Detection of login type can be useful for cases where the type of login that should be used is not known in advance. e.g. jobs defined in other orbs that want to use the azure-cli orb for login

### Description

Add the `login-with-user-or-service-principal` command
