### PR TITLE
mv microsoft/azure-cli to mcr.microsoft.com/azure-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Microsoft's [Azure CLI Docker image](https://hub.docker.com/r/microsoft/azure-cl
 
 ```yaml
 docker:
-  - image: microsoft/azure-cli
+  - image: mcr.microsoft.com/azure-cli
 ```
 
 ### Commands

--- a/src/executors/azure-docker.yml
+++ b/src/executors/azure-docker.yml
@@ -2,4 +2,4 @@ description: >
   Microsoft's Azure CLI Docker image
 
 docker:
-  - image: microsoft/azure-cli
+  - image: mcr.microsoft.com/azure-cli


### PR DESCRIPTION
### Checklist

- [y] All new jobs, commands, executors, parameters have descriptions
- [y] Examples have been added for any significant new features
- [y] README has been updated, if necessary

### Motivation, issues

Microsoft has changed their namespace of the Docker Hub, and it causes an issue to this orb for pulling a docker image.

### Description

- mv microsoft/azure-cli to mcr.microsoft.com/azure-cli