### PR TITLE
#18 Update to use trusted.gpg.d instead of apt-key

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -31,6 +31,7 @@ steps:
 
         # Modify your sources list
 
+        echo "Add Azure CLI software repository"
         echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | \
           $SUDO tee /etc/apt/sources.list.d/azure-cli.list
 
@@ -38,16 +39,26 @@ steps:
           echo "Installing curl"
           $SUDO apt-get -qqy install curl
         fi
+        
+        if [[ $(command -v gpg) == "" ]]; then
+          echo "Installing gpg"
+          $SUDO apt-get -qqy install gnupg
+        fi
 
         # Get the Microsoft signing key
-
-        curl -L https://packages.microsoft.com/keys/microsoft.asc | $SUDO apt-key add -
+        
+        echo "Install Microsoft signing key"
+        curl -sL https://packages.microsoft.com/keys/microsoft.asc | \
+          gpg --dearmor | \
+          $SUDO tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
 
         # Update and install the Azure CLI
 
         # https://github.com/CircleCI-Public/azure-cli-orb/issues/15
         # https://manpages.debian.org/unstable/apt/apt-get.8.en.html
+        echo "Run apt-get update"
         $SUDO apt-get --allow-releaseinfo-change-suite update
+        echo "Run apt-get install"
         $SUDO apt-get -qqy install \
           ca-certificates \
           azure-cli


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Apt-key is now deprecated. 
This is to updated this orb to match Microsoft documentation - https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-linux?pivots=apt

Added additional echo commands to trace if the script hangs on other points

### Description

Removed `apt-key` in commands and replaced with adding the key to the trusted.gpg.d folder. 
