### PR TITLE
#19 Increase no log timeout to 20 mins

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -4,6 +4,7 @@ description: >
 steps:
   - run:
       name: Install Azure CLI, if not available
+      no_output_timeout: 20m      
       command: |
         # Verify the CLI isn't already installed
         # Use which instead of command -v for wider coverage of envs


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

We are seeing the apt-get install azure-cli taking 13 minutes+. This is causing CircleCI to kill the job due the default 10 minutes for no logout - https://support.circleci.com/hc/en-us/articles/360007188574-Build-has-hit-timeout-limit

As we are running with -qq no log output is rendered during the install and thus causes the build to exits in CircleCI

### Description

Increase timeout for the Install Azure task as its timing out before Azure CLI is installed due to the default 10 minutes no log in CircleCI.

The other solution was to remove the `-qq` on `apt-get` but to keep the code consistent with no excess log noise, I just increased the timeout.
