### PR TITLE
[semver:patch] #22 Fix login for service principals with passwords st…

### DIFF
--- a/src/commands/login-with-service-principal.yml
+++ b/src/commands/login-with-service-principal.yml
@@ -28,6 +28,6 @@ steps:
       command: >
         az login \
           --service-principal \
-          --tenant $<<parameters.azure-sp-tenant>> \
-          -u $<<parameters.azure-sp>> \
-          -p "$<<parameters.azure-sp-password>>"
+          --tenant=$<<parameters.azure-sp-tenant>> \
+          -u=$<<parameters.azure-sp>> \
+          -p="$<<parameters.azure-sp-password>>"

--- a/src/commands/login-with-user-or-service-principal.yml
+++ b/src/commands/login-with-user-or-service-principal.yml
@@ -63,16 +63,16 @@ steps:
           echo "User credentials detected; logging in with user"
           az login \
             <<#parameters.alternate-tenant>> \
-            --tenant $<<parameters.azure-tenant>> <</parameters.alternate-tenant>> \
-            -u $<<parameters.azure-username>> \
-            -p "$<<parameters.azure-password>>"
+            --tenant=$<<parameters.azure-tenant>> <</parameters.alternate-tenant>> \
+            -u=$<<parameters.azure-username>> \
+            -p="$<<parameters.azure-password>>"
         elif [ -n "${<< parameters.azure-sp >>}" ]; then
           echo "Service Principal credentials detected; logging in with Service Principal"
           az login \
             --service-principal \
-            --tenant $<<parameters.azure-sp-tenant>> \
-            -u $<<parameters.azure-sp>> \
-            -p "$<<parameters.azure-sp-password>>"
+            --tenant=$<<parameters.azure-sp-tenant>> \
+            -u=$<<parameters.azure-sp>> \
+            -p="$<<parameters.azure-sp-password>>"
         else
           echo "Login failed; neither user nor Service Principal credentials were provided"
           exit 1


### PR DESCRIPTION
…arting with `-`

### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Fixes https://github.com/CircleCI-Public/azure-cli-orb/issues/22

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description

prevent `login-with-service-principal` to fail when SP password starts with `-`

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
