### PR TITLE
Add new parameter to the azure docker image to specify docker tag

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -97,7 +97,7 @@ jobs:
 
   test-orb-alpine-docker-old:
     executor:
-      name: alpine
+      name: azure-cli/azure-docker
       tag: 2.68.0
     steps:
       - azure-cli-tests:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -95,6 +95,15 @@ jobs:
       - azure-cli-tests:
           login-with-service-principal: true
 
+  test-orb-alpine-docker-old:
+    executor:
+      name: alpine
+      parameters:
+        tag: 2.68.0
+    steps:
+      - azure-cli-tests:
+          login-with-service-principal: true
+
 workflows:
   integration-tests_prod-deploy:
     jobs:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -98,8 +98,7 @@ jobs:
   test-orb-alpine-docker-old:
     executor:
       name: alpine
-      parameters:
-        tag: 2.68.0
+      tag: 2.68.0
     steps:
       - azure-cli-tests:
           login-with-service-principal: true

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -119,6 +119,9 @@ workflows:
       - test-orb-alpine-docker:
           context: azure-acr-orb
           filters: *filters
+      - test-orb-alpine-docker-old:
+          context: azure-acr-orb
+          filters: *filters
       - orb-tools/pack:
           filters: *release-filters
       - orb-tools/publish:
@@ -130,6 +133,7 @@ workflows:
             - test-orb-golang
             - test-orb-azure-docker
             - test-orb-alpine-docker
+            - test-orb-alpine-docker-old
             - orb-tools/pack
           context: orb-publisher
           filters:

--- a/src/executors/azure-docker.yml
+++ b/src/executors/azure-docker.yml
@@ -4,7 +4,7 @@ description: >
 
 parameters:
   tag:
-    description: "The `cimg/go` Docker image version tag."
+    description: "The microsoft azure cli Docker image version tag. See: https://mcr.microsoft.com/v2/azure-cli/tags/list"
     type: string
     default: latest
 

--- a/src/executors/azure-docker.yml
+++ b/src/executors/azure-docker.yml
@@ -9,4 +9,4 @@ parameters:
     default: latest
 
 docker:
-  - image: mcr.microsoft.com/azure-cli:<<parameters-tag>>
+  - image: mcr.microsoft.com/azure-cli:<<parameters.tag>>

--- a/src/executors/azure-docker.yml
+++ b/src/executors/azure-docker.yml
@@ -4,7 +4,7 @@ description: >
 
 parameters:
   tag:
-    description: "The microsoft azure cli Docker image version tag. See: https://mcr.microsoft.com/v2/azure-cli/tags/list"
+    description: "The microsoft azure cli Docker image version tag."
     type: string
     default: latest
 

--- a/src/executors/azure-docker.yml
+++ b/src/executors/azure-docker.yml
@@ -2,5 +2,11 @@
 description: >
   Microsoft's Azure CLI Docker image
 
+parameters:
+  tag:
+    description: "The `cimg/go` Docker image version tag."
+    type: string
+    default: latest
+
 docker:
-  - image: mcr.microsoft.com/azure-cli
+  - image: mcr.microsoft.com/azure-cli:<<parameters-tag>>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->
Users need to specify older vesions of the microsoft provided docker image.
### Description

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
This PR adds a tag parameter to the microsoft azure cli docker image to specify which version of azure cli to use.